### PR TITLE
Enable price display mode in themes and admin (SHOOP-2143)

### DIFF
--- a/shoop/admin/modules/contact_groups/views/forms.py
+++ b/shoop/admin/modules/contact_groups/views/forms.py
@@ -26,7 +26,7 @@ from shoop.utils.multilanguage_model_form import MultiLanguageModelForm
 class ContactGroupBaseForm(MultiLanguageModelForm):
     class Meta:
         model = ContactGroup
-        fields = ("name",)
+        fields = ("name", "price_display_option")
 
 
 class ContactGroupBaseFormPart(FormPart):

--- a/shoop/core/migrations/0017_price_display_option.py
+++ b/shoop/core/migrations/0017_price_display_option.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import enumfields.fields
+import shoop.core.pricing
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0016_shop_contact_address'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contactgroup',
+            name='price_display_option',
+            field=enumfields.fields.EnumIntegerField(default=1, enum=shoop.core.pricing.PriceDisplayOption, verbose_name='price display option'),
+        ),
+    ]

--- a/shoop/core/pricing/__init__.py
+++ b/shoop/core/pricing/__init__.py
@@ -50,8 +50,8 @@ from ._context import PricingContext, PricingContextable
 from ._discounts import DiscountModule, get_discount_modules
 from ._module import get_pricing_module, PricingModule
 from ._price import Price, TaxfulPrice, TaxlessPrice
+from ._price_display import PriceDisplayMode, PriceDisplayOption
 from ._price_info import PriceInfo
-from ._pricedisplayoptions import PriceDisplayOptions
 from ._priceful import Priceful
 from ._utils import (
     get_price_info, get_price_infos, get_pricing_steps,
@@ -67,7 +67,8 @@ __all__ = [
     "get_pricing_steps",
     "get_pricing_steps_for_products",
     "Price",
-    "PriceDisplayOptions",
+    "PriceDisplayOption",
+    "PriceDisplayMode",
     "Priceful",
     "PriceInfo",
     "PricingContext",

--- a/shoop/core/pricing/_price_display.py
+++ b/shoop/core/pricing/_price_display.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+from enumfields import Enum
+
+
+class PriceDisplayOption(Enum):
+    HIDE_PRICES = 0
+    DISPLAY_PRICES_AS_STORED = 1
+    DISPLAY_TAXFUL_PRICES = 2
+    DISPLAY_TAXLESS_PRICES = 3
+
+    class Labels:
+        HIDE_PRICES = _("Do not display prices for this group")
+        DISPLAY_PRICES_AS_STORED = _("Display prices as stored in shop")
+        DISPLAY_TAXFUL_PRICES = _("Display taxful prices")
+        DISPLAY_TAXLESS_PRICES = _("Display taxless prices")
+
+
+class PriceDisplayMode(object):
+    def __init__(self, shop=None, option=PriceDisplayOption.HIDE_PRICES):
+        self.hide_prices = (option == PriceDisplayOption.HIDE_PRICES)
+        self.include_taxes = None
+        if option == PriceDisplayOption.DISPLAY_PRICES_AS_STORED:
+            self.include_taxes = shop.prices_include_tax
+        else:
+            self.include_taxes = (option == PriceDisplayOption.DISPLAY_TAXFUL_PRICES)

--- a/shoop/core/pricing/_pricedisplayoptions.py
+++ b/shoop/core/pricing/_pricedisplayoptions.py
@@ -1,3 +1,0 @@
-class PriceDisplayOptions(object):
-    def __init__(self, include_taxes=None):
-        self.include_taxes = include_taxes

--- a/shoop/core/templatetags/price.py
+++ b/shoop/core/templatetags/price.py
@@ -7,7 +7,6 @@ from ._price_filter_impl import (
     _RangePriceDisplayFilter, _TotalPriceDisplayFilter
 )
 
-
 # For Product, SourceLine, BasketLine, OrderLine
 price = _PriceDisplayFilter('price')
 base_price = _PriceDisplayFilter('base_price')

--- a/shoop/front/middleware.py
+++ b/shoop/front/middleware.py
@@ -15,7 +15,6 @@ from django.utils import timezone
 
 from shoop.core.middleware import ExceptionMiddleware
 from shoop.core.models import get_person_contact, Shop
-from shoop.core.pricing import PriceDisplayOptions
 from shoop.front.basket import get_basket
 
 __all__ = ["ProblemMiddleware", "ShoopFrontMiddleware"]
@@ -89,13 +88,8 @@ class ShoopFrontMiddleware(object):
             # TODO: Fallback to request.shop.timezone (and add such field)
 
     def _set_price_display_options(self, request):
-        if request.GET.get('with_taxes') == '1':
-            taxes = True
-        elif request.GET.get('with_taxes') == '0':
-            taxes = False
-        else:
-            taxes = None
-        request.price_display_options = PriceDisplayOptions(include_taxes=taxes)
+        request.price_display_mode = request.customer.get_price_display_mode(request.shop)
+        request.show_prices = not request.price_display_mode.hide_prices
 
     def process_response(self, request, response):
         if hasattr(request, "basket") and request.basket.dirty:

--- a/shoop/themes/classic_gray/templates/classic_gray/navigation_basket_partial.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/navigation_basket_partial.jinja
@@ -1,3 +1,4 @@
+{% if request.show_prices %}
 <li class="dropdown cart">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown">
         <i class="menu-icon fa fa-shopping-cart"></i>
@@ -45,3 +46,4 @@
         {% endif %}
     </div>
 </li>
+{% endif %}

--- a/shoop/themes/classic_gray/templates/classic_gray/product_preview.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/product_preview.jinja
@@ -6,7 +6,7 @@
         <div class="content" id="product-{{ product.id }}-preview">
             <div class="row">
                 <div class="col-md-6 col-sm-5">
-                    {% if product|is_discounted %}
+                    {% if request.show_prices and product|is_discounted %}
                         <div class="discount">
                           <span class="label label-danger">
                             {% set discount_percent = product|discount_percent %}
@@ -24,9 +24,11 @@
                 <div class="col-md-6 col-sm-7">
                     <h2>{{ product.name }}</h2>
                     {% if product.description %}<p class="description">{{ product.description|safe|truncate(150, False) }}</p>{% endif %}
+                    {% if request.show_prices %}
                     <div class="product-price">
                         {{ macros.render_product_price(product) }}
                     </div>
+                    {% endif %}
                     <hr>
                     {% include "shoop/front/product/_detail_order_section.jinja" with context %}
                     <a href="{{ product_url }}" class="btn-open-page btn btn-default btn-block"><i class="fa fa-search"></i> {% trans %}Open product page{% endtrans %} <i class="fa fa-angle-double-right"></i></a>

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
@@ -1,13 +1,15 @@
 {% macro product_box(product, show_image=True, show_description=True, class="product-box", thumbnail_size=(500,500)) %}
     {% set u = url("shoop:product", pk=product.pk, slug=product.slug) %}
-    {% if product.is_variation_parent()  %}
-        {% set price_info = product.get_cheapest_child_price_info(request) %}
-    {% else %}
-        {% set price_info = product.get_price_info(request) %}
+    {% if request.show_prices %}
+        {% if product.is_variation_parent()  %}
+            {% set price_info = product.get_cheapest_child_price_info(request) %}
+        {% else %}
+            {% set price_info = product.get_price_info(request) %}
+        {% endif %}
     {% endif %}
     <div class="product-card {{ class }}" id="product-{{ product.id }}">
         <a href="{{ u }}" rel="product-detail" title="{{ product.name }}">
-            {% if price_info.is_discounted %}
+            {% if request.show_prices and price_info.is_discounted %}
                 <div class="labels">
                     <span class="label label-sale">{{ -price_info.discount_rate|percent }}</span>
                 </div>
@@ -23,9 +25,11 @@
                 {% if show_description and product.description %}
                     <p class="description">{{ product.description|striptags|truncate(180)|safe }}</p>
                 {% endif %}
+                {% if request.show_prices %}
                 <div class="price">
-                    {{ render_product_price(product, price_info, show_units=False) }}
+                    {{ render_product_price(product, show_units=False) }}
                 </div>
+                {% endif %}
             </div>
         </a>
         <div class="actions clearfix">
@@ -276,7 +280,7 @@
 {% endmacro %}
 
 
-{% macro render_product_price(product, price_info=None, show_units=True) %}
+{% macro render_product_price(product, show_units=True) %}
 <div class="price-line">
     <span class="lead">
         {%- if product.is_variation_parent() -%}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section.jinja
@@ -46,6 +46,7 @@
 {% endmacro %}
 
 {% macro product_order_section(product, quantity, is_orderable) %}
+    {% if request.show_prices %}
     <div class="row">
         <div class="col-sm-6">
             {{ quantity_box() }}
@@ -55,20 +56,20 @@
         </div>
     </div>
     {{ add_to_cart_btn(is_orderable) }}
+    {% endif %}
 {% endmacro %}
 
 {% macro product_price_div(product, quantity) %}
     <div class="price text-right" id="product-price-div">
-        {% set price_info = product.get_price_info(request, quantity) %}
         <h2>
             <small class="text-muted">{% trans %}Total{% endtrans %}:</small>
-            <span id="product-price"><strong>{{ price_info.price|money }}</strong></span>
+            <span id="product-price"><strong>{{ product|price }}</strong></span>
         </h2>
         <span class="small text-muted">
-            {% if price_info.is_discounted %}
-            (<s>{{ price_info.base_unit_price|money }}</s>)
+            {% if product|is_discounted %}
+            (<s>{{ product|base_unit_price }}</s>)
             {% endif %}
-            {{ price_info.discounted_unit_price|money }}/{{ product.sales_unit.short_name }}
+            {{ product|discounted_unit_price }}/{{ product.sales_unit.short_name }}
         </span>
     </div>
 {% endmacro %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
@@ -1,11 +1,5 @@
 {% extends "shoop/front/base.jinja" %}
 
-{% if product.is_variation_parent()  %}
-    {% set priceinfo = product.get_cheapest_child_price_info(request) %}
-{% else %}
-    {% set priceinfo = product.get_price_info(request) %}
-{% endif %}
-
 {% block extrameta %}
     <meta property="og:site_name" content="{{ request.shop }}">
     <meta property="og:type" content="product">
@@ -43,17 +37,19 @@
                 {% if product.description %}
                     <p class="product-short-description">{{ product.description|safe|truncate(150, False) }}</p>
                 {% endif %}
+                {% if request.show_prices %}
                 <div class="product-price">
-                    {{ macros.render_product_price(product, priceinfo) }}
+                    {{ macros.render_product_price(product) }}
                 </div>
+                {% endif %}
                 <hr>
             </div>
         </div>
         <div class="product-image col-sm-6 col-md-5">
-            {% if priceinfo.is_discounted %}
+            {% if request.show_prices and product|is_discounted %}
                 <div class="discount">
                   <span class="label label-danger">
-                    {% set discount_percent = priceinfo.discount_rate|percent %}
+                    {% set discount_percent = product|discount_percent %}
                     {{- _("Save %(discount_percent)s", discount_percent=discount_percent) -}}
                   </span>
                 </div>
@@ -67,9 +63,11 @@
                 {% if product.description %}
                     <p class="product-short-description">{{ product.description|safe|truncate(150, False) }}</p>
                 {% endif %}
+                {% if show_prices %}
                 <div class="product-price">
-                    {{ macros.render_product_price(product, priceinfo) }}
+                    {{ macros.render_product_price(product) }}
                 </div>
+                {% endif %}
             </div>
             {% placeholder "product_extra_1" %}{% endplaceholder %}
             <hr>

--- a/tax-display-plan.rst
+++ b/tax-display-plan.rst
@@ -1,8 +1,8 @@
-Price displaying pre-tax or with taxes
-======================================
+Price displaying hide prides, pre-tax or with taxes
+===================================================
 
-Notes on how to implement displaying prices pre-tax or with taxes based
-on customer or customer group preference.
+Notes on how to implement displaying prices hide prices, pre-tax or with taxes
+based on customer or customer group preference.
 
 Terms
 -----
@@ -28,6 +28,12 @@ Open Questions
   * Currently I decided to use the same display taxness for prices in
     basket but not for orders.
 
+* Should we block access to basket and checkout if prices is hidden?
+
+* Should we block adding to basket if prices is hidden?
+
+* Should we raise from pricing filters if the hide price mode is on?
+
 Plan
 ----
 
@@ -50,3 +56,4 @@ TODO
 
 * Calculating taxes for basket does not work yet.  It seems that
   ``basket.tax_amount`` always returns 0 EUR.
+* Add translation for ``PriceDisplayOption`` enum


### PR DESCRIPTION
- Allow merchant to select `PriceDisplayOption` for `ContactGroup`
- Use `PriceDisplayOption` to set price_display_mode for request
- `PriceDisplayMode` tells price filters whether to show prices and
  if so whether to use include taxes into prices
- Add show_prices variable to request to indicate whether prices
  should be visible in current price display mode
- Make pricing in template respect the request price_display_mode
  by using new pricing filters

Refs SHOOP-1981 / SHOOP-2143
